### PR TITLE
Fix scanline alignment in the screen capturer.

### DIFF
--- a/ScreenCapturer.cpp
+++ b/ScreenCapturer.cpp
@@ -5,7 +5,9 @@
 ScreenCapturer::ScreenCapturer(int frameWidth, int frameHeight){
 	imageWidth = frameWidth;
 	imageHeight = frameHeight;
-	length = imageWidth*imageHeight * 3;
+	// Round up the scan line size to a multiple of 4
+	int imageStride = (imageWidth * 3 + 3) / 4 * 4;
+	length = imageStride * imageHeight;
 
 	//Screen capture buffer
 	GRAPHICS::_GET_SCREEN_ACTIVE_RESOLUTION(&windowWidth, &windowHeight);


### PR DESCRIPTION
Hi,

This is a short fix to allow non-multiple-of-4 width in the screen capturer.
Scanlines of Windows bitmaps must be aligned to 4 bytes.
Without this fix, the length is smaller than the amount of bytes copied by GetDIBits.

Thanks.